### PR TITLE
Send content in Text instead of Attachment

### DIFF
--- a/meeseeks/meeseeks.go
+++ b/meeseeks/meeseeks.go
@@ -20,8 +20,10 @@ import (
 
 // ChatClient interface that provides a way of replying to messages on a channel
 type ChatClient interface {
-	Reply(text, color, channel string) error
-	ReplyIM(text, color, user string) error
+	Reply(text, channel string) error
+	ReplyWithAttachment(text, color, channel string) error
+	ReplyIM(text, user string) error
+	ReplyIMWithAttachment(text, color, user string) error
 }
 
 // Meeseeks is the command execution engine

--- a/meeseeks/replies.go
+++ b/meeseeks/replies.go
@@ -13,7 +13,7 @@ func (m *Meeseeks) replyWithError(msg message.Message, err error) {
 		log.Fatalf("could not render failure template: %s", err)
 	}
 
-	if err = m.client.Reply(content, m.formatter.ErrorColor(), msg.GetChannelID()); err != nil {
+	if err = m.client.ReplyWithAttachment(content, m.formatter.ErrorColor(), msg.GetChannelID()); err != nil {
 		log.Errorf("Failed to reply: %s", err)
 	}
 }
@@ -26,7 +26,7 @@ func (m *Meeseeks) replyWithUnknownCommand(req request.Request) {
 		log.Fatalf("could not render unknown command template: %s", err)
 	}
 
-	if err = m.client.Reply(msg, m.formatter.ErrorColor(), req.ChannelID); err != nil {
+	if err = m.client.ReplyWithAttachment(msg, m.formatter.ErrorColor(), req.ChannelID); err != nil {
 		log.Errorf("Failed to reply: %s", err)
 	}
 }
@@ -40,7 +40,7 @@ func (m *Meeseeks) replyWithHandshake(req request.Request, cmd command.Command) 
 		log.Fatalf("could not render unknown command template: %s", err)
 	}
 
-	if err = m.client.Reply(msg, m.formatter.InfoColor(), req.ChannelID); err != nil {
+	if err = m.client.ReplyWithAttachment(msg, m.formatter.InfoColor(), req.ChannelID); err != nil {
 		log.Errorf("Failed to reply: %s", err)
 	}
 }
@@ -54,7 +54,7 @@ func (m *Meeseeks) replyWithUnauthorizedCommand(req request.Request, cmd command
 		log.Fatalf("could not render unathorized command template %s", err)
 	}
 
-	if err = m.client.Reply(msg, m.formatter.ErrorColor(), req.ChannelID); err != nil {
+	if err = m.client.ReplyWithAttachment(msg, m.formatter.ErrorColor(), req.ChannelID); err != nil {
 		log.Errorf("Failed to reply: %s", err)
 	}
 }
@@ -65,7 +65,7 @@ func (m *Meeseeks) replyWithCommandFailed(req request.Request, cmd command.Comma
 		log.Fatalf("could not render failure template %s", err)
 	}
 
-	if err = m.client.Reply(msg, m.formatter.ErrorColor(), req.ChannelID); err != nil {
+	if err = m.client.ReplyWithAttachment(msg, m.formatter.ErrorColor(), req.ChannelID); err != nil {
 		log.Errorf("Failed to reply: %s", err)
 	}
 }
@@ -77,7 +77,7 @@ func (m *Meeseeks) replyWithSuccess(req request.Request, cmd command.Command, ou
 		log.Fatalf("could not render success template %s", err)
 	}
 
-	if err = m.client.Reply(msg, m.formatter.SuccessColor(), req.ChannelID); err != nil {
+	if err = m.client.Reply(msg, req.ChannelID); err != nil {
 		log.Errorf("Failed to reply: %s", err)
 	}
 }

--- a/testingstubs/testingstubs.go
+++ b/testingstubs/testingstubs.go
@@ -109,13 +109,25 @@ func newClientStub() ClientStub {
 }
 
 // Reply implements the meeseeks.Client.Reply interface
-func (c ClientStub) Reply(text, color, channel string) error {
+func (c ClientStub) Reply(text, channel string) error {
+	c.MessagesSent <- SentMessage{Text: text, Channel: channel}
+	return nil
+}
+
+// ReplyWithAttachment implements the meeseeks.Client.ReplyWithAttachment interface
+func (c ClientStub) ReplyWithAttachment(text, color, channel string) error {
 	c.MessagesSent <- SentMessage{Text: text, Color: color, Channel: channel}
 	return nil
 }
 
 // ReplyIM implements the meeseeks.Client.ReplyIM interface
-func (c ClientStub) ReplyIM(text, color, user string) error {
+func (c ClientStub) ReplyIM(text, user string) error {
+	c.MessagesSent <- SentMessage{Text: text, Channel: user, IsIM: true}
+	return nil
+}
+
+// ReplyIMWithAttachment implements the meeseeks.Client.ReplyIMWithAttachment interface
+func (c ClientStub) ReplyIMWithAttachment(text, color, user string) error {
 	c.MessagesSent <- SentMessage{Text: text, Color: color, Channel: user, IsIM: true}
 	return nil
 }


### PR DESCRIPTION
Adds support for sending _regular_ messages - instead of messages with content sent as attachment, and changes the `replyWithSuccess` to use this regular message.

I found _attachment_ messages problematic, since:
- content has limited width (so wider output is wrapped at hardcoded row width),
- doesn't have support for some slack features (like unfurling URLs sent with message).

This change adds a strict change, but I think ideally would be to allow user to decide, if output should be sent with attachment or with _regular_ message (with setting one of them as the default). I can update the PR to such form if requested :).