### PR TITLE
Aliases

### DIFF
--- a/aliases/aliases.go
+++ b/aliases/aliases.go
@@ -22,7 +22,7 @@ type Alias struct {
 }
 
 // Add adds a new alias for a user ID
-func Add(userID, alias, command string) error {
+func Create(userID, alias, command string) error {
 	return db.Update(func(tx *bolt.Tx) error {
 		bucket, err := getAliasesBucket(userID, tx)
 		if err != nil {
@@ -32,7 +32,7 @@ func Add(userID, alias, command string) error {
 		a := Alias{
 			Alias:   alias,
 			Command: cmdChunks[0],
-			Args:    cmdChunks[1:len(cmdChunks)],
+			Args:    cmdChunks[1:],
 		}
 		aj, err := json.Marshal(a)
 		if err != nil {

--- a/aliases/aliases.go
+++ b/aliases/aliases.go
@@ -3,7 +3,6 @@ package aliases
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	bolt "github.com/coreos/bbolt"
 	"github.com/gomeeseeks/meeseeks-box/db"
@@ -21,18 +20,17 @@ type Alias struct {
 	Args    []string
 }
 
-// Add adds a new alias for a user ID
-func Create(userID, alias, command string) error {
+// Create adds a new alias for a user ID
+func Create(userID, alias, command string, args ...string) error {
 	return db.Update(func(tx *bolt.Tx) error {
 		bucket, err := getAliasesBucket(userID, tx)
 		if err != nil {
 			return err
 		}
-		cmdChunks := strings.Split(command, " ")
 		a := Alias{
 			Alias:   alias,
-			Command: cmdChunks[0],
-			Args:    cmdChunks[1:],
+			Command: command,
+			Args:    args,
 		}
 		aj, err := json.Marshal(a)
 		if err != nil {

--- a/aliases/aliases.go
+++ b/aliases/aliases.go
@@ -75,8 +75,8 @@ func List(userID string) ([]Alias, error) {
 			return err
 		}
 		cur := bucket.Cursor()
-		a := Alias{}
 		for _, payload := cur.First(); payload != nil; _, payload = cur.Next() {
+			a := Alias{}
 			json.Unmarshal(payload, &a)
 			aliases = append(aliases, a)
 		}

--- a/aliases/aliases.go
+++ b/aliases/aliases.go
@@ -3,6 +3,7 @@ package aliases
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/sirupsen/logrus"
 
 	bolt "github.com/coreos/bbolt"
 	"github.com/gomeeseeks/meeseeks-box/db"
@@ -88,6 +89,7 @@ func List(userID string) ([]Alias, error) {
 
 // Get returns the command for an alias
 func Get(userID, alias string) (string, []string, error) {
+	logrus.Debugf("looking up command %s", alias)
 	var a Alias
 	err := db.Update(func(tx *bolt.Tx) error {
 		bucket, err := getAliasesBucket(userID, tx)

--- a/aliases/aliases.go
+++ b/aliases/aliases.go
@@ -1,0 +1,83 @@
+package aliases
+
+import (
+	"fmt"
+
+	bolt "github.com/coreos/bbolt"
+	"github.com/gomeeseeks/meeseeks-box/db"
+)
+
+var aliasesBucketKey = []byte("aliases")
+
+// Add adds a new alias for a user ID
+func Add(userID, alias, command string) error {
+	return db.Update(func(tx *bolt.Tx) error {
+		bucket, err := getAliasesBucket(userID, tx)
+		if err != nil {
+			return err
+		}
+		return bucket.Put([]byte(alias), []byte(command))
+	})
+}
+
+// Delete deletes an alias for a user ID
+func Delete(userID, alias string) error {
+	return db.Update(func(tx *bolt.Tx) error {
+		bucket, err := getAliasesBucket(userID, tx)
+		if err != nil {
+			return err
+		}
+		if k := bucket.Get([]byte(alias)); k == nil {
+			return fmt.Errorf("alias not found")
+		}
+		err = bucket.Delete([]byte(alias))
+		if err != nil {
+			return err
+		}
+
+		// Delete the bucket if no more aliases are present
+		cur := bucket.Cursor()
+		if k, _ := cur.First(); k == nil {
+			deleteAliasesBucket(userID, tx)
+		}
+		return nil
+	})
+}
+
+// List returns all configured aliases for a user ID
+func List(userID string) (map[string]string, error) {
+	aliases := make(map[string]string)
+	err := db.Update(func(tx *bolt.Tx) error {
+		bucket, err := getAliasesBucket(userID, tx)
+		if err != nil {
+			return err
+		}
+		cur := bucket.Cursor()
+		for a, c := cur.First(); a != nil; a, c = cur.Next() {
+			aliases[string(a[:])] = string(c[:])
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return aliases, nil
+}
+
+// getAliasesBucket returns the aliases for a user ID
+func getAliasesBucket(userID string, tx *bolt.Tx) (*bolt.Bucket, error) {
+	aliasesBucket, err := tx.CreateBucketIfNotExists(aliasesBucketKey)
+	if err != nil {
+		return nil, fmt.Errorf("could not get aliases bucket: %s", err)
+	}
+	return aliasesBucket.CreateBucketIfNotExists([]byte(userID))
+}
+
+// deleteAliasesBucket returns the aliases for a user ID
+func deleteAliasesBucket(userID string, tx *bolt.Tx) error {
+	aliasesBucket, err := tx.CreateBucketIfNotExists(aliasesBucketKey)
+	if err != nil {
+		return fmt.Errorf("could not get aliases bucket: %s", err)
+	}
+	return aliasesBucket.DeleteBucket([]byte(userID))
+}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -6,8 +6,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// AdminGroup is the name of the admin group
 const AdminGroup = "admin"
 
+// CommandAuthorization is the interface for the command authorization
 type CommandAuthorization interface {
 	AuthStrategy() string
 	AllowedGroups() []string

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -12,7 +12,7 @@ import (
 
 func Test_Auth(t *testing.T) {
 	auth.Configure(map[string][]string{
-		auth.AdminGroup: []string{"admin_user"},
+		auth.AdminGroup: {"admin_user"},
 	})
 	commands.Add("any", shell.New(shell.CommandOpts{
 		Cmd:          "any",
@@ -104,14 +104,14 @@ func Test_Auth(t *testing.T) {
 func Test_Groups(t *testing.T) {
 	auth.Configure(
 		map[string][]string{
-			auth.AdminGroup: []string{"user1", "user2"},
-			"developer":     []string{"user1"},
+			auth.AdminGroup: {"user1", "user2"},
+			"developer":     {"user1"},
 		},
 	)
 	stubs.AssertEquals(t,
 		map[string][]string{
-			"developer":     []string{"user1"},
-			auth.AdminGroup: []string{"user1", "user2"},
+			"developer":     {"user1"},
+			auth.AdminGroup: {"user1", "user2"},
 		},
 		auth.GetGroups())
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -91,7 +91,7 @@ func Test_Auth(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			stubs.Must(t, tc.name, stubs.WithTmpDB(func(_ string) {
-				cmd, ok := commands.Find(tc.req)
+				cmd, ok := commands.Find(&tc.req)
 				stubs.AssertEquals(t, true, ok)
 				if actual := auth.Check(tc.username, cmd); actual != tc.expected {
 					t.Fatalf("Check failed with %s", actual)

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gomeeseeks/meeseeks-box/auth"
 	"github.com/gomeeseeks/meeseeks-box/commands"
 	"github.com/gomeeseeks/meeseeks-box/commands/shell"
+	"github.com/gomeeseeks/meeseeks-box/meeseeks/request"
 	stubs "github.com/gomeeseeks/meeseeks-box/testingstubs"
 )
 
@@ -30,42 +31,72 @@ func Test_Auth(t *testing.T) {
 	tt := []struct {
 		name     string
 		username string
-		cmd      string
+		req      request.Request
 		expected error
 	}{
 		{
 			name:     "any",
 			username: "myself",
-			cmd:      "any",
+			req: request.Request{
+				Command:     "any",
+				Channel:     "general",
+				ChannelID:   "123",
+				ChannelLink: "<#123>",
+				Username:    "myself",
+				UserID:      "userid",
+			},
 			expected: nil,
 		},
 		{
 			name:     "none",
 			username: "myself",
-			cmd:      "none",
+			req: request.Request{
+				Command:     "none",
+				Channel:     "general",
+				ChannelID:   "123",
+				ChannelLink: "<#123>",
+				Username:    "myself",
+				UserID:      "userid",
+			},
 			expected: auth.ErrUserNotAllowed,
 		},
 		{
 			name:     "authorized groups",
 			username: "admin_user",
-			cmd:      "admins",
+			req: request.Request{
+				Command:     "admins",
+				Channel:     "general",
+				ChannelID:   "123",
+				ChannelLink: "<#123>",
+				Username:    "myself",
+				UserID:      "userid",
+			},
 			expected: nil,
 		},
 		{
 			name:     "authorized groups with unauthorized user",
 			username: "normal_user",
-			cmd:      "admins",
+			req: request.Request{
+				Command:     "admins",
+				Channel:     "general",
+				ChannelID:   "123",
+				ChannelLink: "<#123>",
+				Username:    "myself",
+				UserID:      "userid",
+			},
 			expected: auth.ErrUserNotAllowed,
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd, ok := commands.Find(tc.cmd)
-			stubs.AssertEquals(t, true, ok)
-			if actual := auth.Check(tc.username, cmd); actual != tc.expected {
-				t.Fatalf("Check failed with %s", actual)
-			}
+			stubs.Must(t, tc.name, stubs.WithTmpDB(func(_ string) {
+				cmd, ok := commands.Find(tc.req)
+				stubs.AssertEquals(t, true, ok)
+				if actual := auth.Check(tc.username, cmd); actual != tc.expected {
+					t.Fatalf("Check failed with %s", actual)
+				}
+			}))
 		})
 	}
 }

--- a/commands/builtins/builtins.go
+++ b/commands/builtins/builtins.go
@@ -842,7 +842,7 @@ type getAliasesCommand struct {
 	defaultTimeout
 }
 
-var getAliasesTemplate = `{{ if eq (len .aliases) 0 }}No alias could be found{{ else }}{{ range $a, $c := .aliases }}- *{{ $a }}* - ` + "`" + `{{ $c }}` + "`" + `
+var getAliasesTemplate = `{{ if eq (len .aliases) 0 }}No alias could be found{{ else }}{{ range $a := .aliases }}- *{{ $a.Alias }}* - ` + "`" + `{{ $a.Command }} {{ range $arg := $a.Args }}{{ $arg }} {{ end }}` + "`" + `
 {{ end }}{{ end }}`
 
 func (l getAliasesCommand) Execute(_ context.Context, job jobs.Job) (string, error) {

--- a/commands/builtins/builtins.go
+++ b/commands/builtins/builtins.go
@@ -41,7 +41,7 @@ const (
 	BuiltinListAPITokenCommand   = "tokens"
 	BuiltinRevokeAPITokenCommand = "token-revoke"
 
-	BuiltinAddAliasCommand    = "alias"
+	BuiltinNewAliasCommand    = "alias"
 	BuiltinDeleteAliasCommand = "unalias"
 	BuiltinGetAliasesCommand  = "aliases"
 )
@@ -103,9 +103,9 @@ var Commands = map[string]command.Command{
 		help: help{"revokes an API token"},
 		cmd:  cmd{BuiltinRevokeAPITokenCommand},
 	},
-	BuiltinAddAliasCommand: addAliasCommand{
+	BuiltinNewAliasCommand: newAliasCommand{
 		help: help{"adds an alias for a command"},
-		cmd:  cmd{BuiltinAddAliasCommand},
+		cmd:  cmd{BuiltinNewAliasCommand},
 	},
 	BuiltinDeleteAliasCommand: deleteAliasCommand{
 		help: help{"deletes an alias for a command"},
@@ -784,7 +784,7 @@ func (l listAPITokensCommand) Execute(_ context.Context, job jobs.Job) (string, 
 	})
 }
 
-type addAliasCommand struct {
+type newAliasCommand struct {
 	cmd
 	help
 	noHandshake
@@ -795,14 +795,14 @@ type addAliasCommand struct {
 	defaultTimeout
 }
 
-func (l addAliasCommand) Execute(_ context.Context, job jobs.Job) (string, error) {
+func (l newAliasCommand) Execute(_ context.Context, job jobs.Job) (string, error) {
 	if len(job.Request.Args) < 2 {
 		return "", fmt.Errorf("an alias requires at least two arguments: the alias and the command")
 	}
 
 	args := job.Request.Args
 	command := strings.Join(args[1:], " ")
-	if err := aliases.Add(job.Request.UserID, args[0], command); err != nil {
+	if err := aliases.Create(job.Request.UserID, args[0], command); err != nil {
 		return fmt.Sprintf("failed to create the alias. Error: %s", err), err
 	}
 	return "alias created successfully", nil

--- a/commands/builtins/builtins.go
+++ b/commands/builtins/builtins.go
@@ -801,7 +801,7 @@ func (l addAliasCommand) Execute(_ context.Context, job jobs.Job) (string, error
 	}
 
 	args := job.Request.Args
-	command := strings.Join(args[1:len(args)], " ")
+	command := strings.Join(args[1:], " ")
 	if err := aliases.Add(job.Request.UserID, args[0], command); err != nil {
 		return fmt.Sprintf("failed to create the alias. Error: %s", err), err
 	}
@@ -842,7 +842,7 @@ type getAliasesCommand struct {
 	defaultTimeout
 }
 
-var getAliasesTemplate = `{{ if eq (len .aliases) 0 }}No alias could be found{{ else }}{{ range $a := .aliases }}- *{{ $a.Alias }}* - ` + "`" + `{{ $a.Command }} {{ range $arg := $a.Args }}{{ $arg }} {{ end }}` + "`" + `
+var getAliasesTemplate = `{{ if eq (len .aliases) 0 }}No alias could be found{{ else }}{{ range $a := .aliases }}- *{{ $a.Alias }}* - ` + "`" + `{{ $a.Command }}{{ range $arg := $a.Args }} {{ $arg }}{{ end }}` + "`" + `
 {{ end }}{{ end }}`
 
 func (l getAliasesCommand) Execute(_ context.Context, job jobs.Job) (string, error) {

--- a/commands/builtins/builtins.go
+++ b/commands/builtins/builtins.go
@@ -801,8 +801,7 @@ func (l newAliasCommand) Execute(_ context.Context, job jobs.Job) (string, error
 	}
 
 	args := job.Request.Args
-	command := strings.Join(args[1:], " ")
-	if err := aliases.Create(job.Request.UserID, args[0], command); err != nil {
+	if err := aliases.Create(job.Request.UserID, args[0], args[1], args[2:]...); err != nil {
 		return fmt.Sprintf("failed to create the alias. Error: %s", err), err
 	}
 	return "alias created successfully", nil

--- a/commands/builtins/builtins_test.go
+++ b/commands/builtins/builtins_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 var basicGroups = map[string][]string{
-	"admins": []string{"admin_user"},
-	"other":  []string{"user_one", "user_two"},
+	"admins": {"admin_user"},
+	"other":  {"user_one", "user_two"},
 }
 
 var req = request.Request{
@@ -242,10 +242,10 @@ func Test_BuiltinCommands(t *testing.T) {
 				},
 			},
 			setup: func() {
-				err := aliases.Add("userid", "first", "command -with args")
+				err := aliases.Create("userid", "first", "command -with args")
 				stubs.Must(t, "create first alias", err)
 
-				err = aliases.Add("userid", "second", "another -command")
+				err = aliases.Create("userid", "second", "another -command")
 				stubs.Must(t, "create second alias", err)
 			},
 			expected: "- *first* - `command -with args`\n- *second* - `another -command`\n",

--- a/commands/builtins/builtins_test.go
+++ b/commands/builtins/builtins_test.go
@@ -216,7 +216,7 @@ func Test_BuiltinCommands(t *testing.T) {
 		{
 			name: "test alias command",
 			req: request.Request{
-				Command: builtins.BuiltinAddAliasCommand,
+				Command: builtins.BuiltinNewAliasCommand,
 				UserID:  "userid",
 			},
 
@@ -242,10 +242,10 @@ func Test_BuiltinCommands(t *testing.T) {
 				},
 			},
 			setup: func() {
-				err := aliases.Create("userid", "first", "command -with args")
+				err := aliases.Create("userid", "first", "command", []string{"-with args"}...)
 				stubs.Must(t, "create first alias", err)
 
-				err = aliases.Create("userid", "second", "another -command")
+				err = aliases.Create("userid", "second", "another", []string{"-command"}...)
 				stubs.Must(t, "create second alias", err)
 			},
 			expected: "- *first* - `command -with args`\n- *second* - `another -command`\n",
@@ -264,10 +264,10 @@ func Test_BuiltinCommands(t *testing.T) {
 				},
 			},
 			setup: func() {
-				err := aliases.Add("userid", "command", "command -with args")
+				err := aliases.Create("userid", "command", "command", []string{"-with", "args"}...)
 				stubs.Must(t, "create first alias", err)
 
-				err = aliases.Add("userid", "second", "another -command")
+				err = aliases.Create("userid", "second", "another", []string{"-command"}...)
 				stubs.Must(t, "create second alias", err)
 
 				err = aliases.Delete("userid", "command")

--- a/commands/builtins/builtins_test.go
+++ b/commands/builtins/builtins_test.go
@@ -453,7 +453,7 @@ func Test_BuiltinCommands(t *testing.T) {
 				if tc.setup != nil {
 					tc.setup()
 				}
-				cmd, ok := commands.Find(tc.req)
+				cmd, ok := commands.Find(&tc.req)
 				if !ok {
 					t.Fatalf("could not find command %s", tc.req.Command)
 				}
@@ -502,7 +502,7 @@ func Test_FilterJobsAudit(t *testing.T) {
 		jobs.Create(r1)
 		jobs.Create(r2)
 
-		cmd, ok := commands.Find(request.Request{
+		cmd, ok := commands.Find(&request.Request{
 			Command: "audit",
 			UserID:  "userid",
 		})

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -3,8 +3,11 @@ package commands
 import (
 	"sync"
 
+	"github.com/gomeeseeks/meeseeks-box/aliases"
 	"github.com/gomeeseeks/meeseeks-box/command"
 	"github.com/gomeeseeks/meeseeks-box/commands/builtins"
+	"github.com/gomeeseeks/meeseeks-box/meeseeks/request"
+	"github.com/sirupsen/logrus"
 )
 
 var commands map[string]command.Command
@@ -31,8 +34,14 @@ func Reset() {
 //
 // This method implements the map interface as in returning true of false in the
 // case the command exists in the map
-func Find(name string) (command.Command, bool) {
-	cmd, ok := commands[name]
+func Find(req request.Request) (command.Command, bool) {
+	c, args, _ := aliases.Get(req.UserID, req.Command)
+	if c != "" {
+		logrus.Debugf("Found alias for %s: %s %v", req.Command, c, args)
+		req.Command = c
+		req.Args = args
+	}
+	cmd, ok := commands[req.Command]
 	return cmd, ok
 }
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -30,25 +30,31 @@ func Reset() {
 	builtins.AddHelpCommand(commands)
 }
 
-// Find looks up the given command by name and returns.
-//
-// This method implements the map interface as in returning true of false in the
-// case the command exists in the map
-func Find(req request.Request) (command.Command, bool) {
-	c, args, _ := aliases.Get(req.UserID, req.Command)
-	if c != "" {
-		logrus.Debugf("Found alias for %s: %s %v", req.Command, c, args)
-		req.Command = c
-		req.Args = args
-	}
-	cmd, ok := commands[req.Command]
-	return cmd, ok
-}
-
 // Add adds a new command to the map
 func Add(name string, cmd command.Command) {
 	mutex.Lock()
 	defer mutex.Unlock()
 
 	commands[name] = cmd
+}
+
+// Find looks up the given command by name and returns.
+//
+// This method implements the map interface as in returning true of false in the
+// case the command exists in the map
+func Find(req *request.Request) (command.Command, bool) {
+	aliasedCommand, args, err := aliases.Get(req.UserID, req.Command)
+	if err != nil {
+		logrus.Errorf("Failed to get alias %s", req.Command)
+	}
+
+	if cmd, ok := commands[aliasedCommand]; ok {
+		logrus.Infof("Command %s is an alias", aliasedCommand)
+		req.Args = append(args, req.Args...)
+
+		return cmd, ok
+	}
+
+	cmd, ok := commands[req.Command]
+	return cmd, ok
 }

--- a/commands/shell/shell.go
+++ b/commands/shell/shell.go
@@ -40,6 +40,7 @@ type shellCommand struct {
 // Execute implements Command.Execute for the ShellCommand
 func (c shellCommand) Execute(ctx context.Context, job jobs.Job) (string, error) {
 	cmdArgs := append(c.Args(), job.Request.Args...)
+	logrus.Debugf("Calling command %s with args %#v", c.Cmd(), cmdArgs)
 
 	ctx, cancelFunc := context.WithTimeout(ctx, c.Timeout())
 	defer cancelFunc()
@@ -123,6 +124,7 @@ func (c shellCommand) AllowedGroups() []string {
 }
 
 func (c shellCommand) Args() []string {
+	logrus.Debug("Returning shell command args ", c.opts.Args)
 	if c.opts.Args == nil {
 		return []string{}
 	}

--- a/meeseeks/meeseeks.go
+++ b/meeseeks/meeseeks.go
@@ -70,7 +70,7 @@ func (m *Meeseeks) Start() {
 			m.replyWithError(msg, err)
 			continue
 		}
-		cmd, ok := commands.Find(req)
+		cmd, ok := commands.Find(&req)
 		if !ok {
 			m.replyWithUnknownCommand(req)
 			continue

--- a/meeseeks/meeseeks.go
+++ b/meeseeks/meeseeks.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/gomeeseeks/meeseeks-box/aliases"
 	"github.com/gomeeseeks/meeseeks-box/commands/builtins"
 	"github.com/sirupsen/logrus"
 
@@ -71,13 +70,7 @@ func (m *Meeseeks) Start() {
 			m.replyWithError(msg, err)
 			continue
 		}
-		c, args, _ := aliases.Get(req.UserID, req.Command)
-		if c != "" {
-			logrus.Debugf("Found alias for %s: %s %v", req.Command, c, args)
-			req.Command = c
-			req.Args = args
-		}
-		cmd, ok := commands.Find(req.Command)
+		cmd, ok := commands.Find(req)
 		if !ok {
 			m.replyWithUnknownCommand(req)
 			continue

--- a/meeseeks/meeseeks.go
+++ b/meeseeks/meeseeks.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/gomeeseeks/meeseeks-box/aliases"
 	"github.com/gomeeseeks/meeseeks-box/commands/builtins"
 	"github.com/sirupsen/logrus"
 
@@ -70,7 +71,12 @@ func (m *Meeseeks) Start() {
 			m.replyWithError(msg, err)
 			continue
 		}
-
+		c, args, _ := aliases.Get(req.UserID, req.Command)
+		if c != "" {
+			logrus.Debugf("Found alias for %s: %s %v", req.Command, c, args)
+			req.Command = c
+			req.Args = args
+		}
 		cmd, ok := commands.Find(req.Command)
 		if !ok {
 			m.replyWithUnknownCommand(req)

--- a/meeseeks/meeseeks_test.go
+++ b/meeseeks/meeseeks_test.go
@@ -40,12 +40,12 @@ func Test_MeeseeksInteractions(t *testing.T) {
 			message: "echo hello!",
 			channel: "general",
 			expected: []expectedMessage{
-				expectedMessage{
+				{
 					TextMatcher: handshakeMatcher,
 					Channel:     "generalID",
 					IsIM:        false,
 				},
-				expectedMessage{
+				{
 					TextMatcher: "^<@myuser> .*\n```\nhello!\n```$",
 					Channel:     "generalID",
 					IsIM:        false,
@@ -58,12 +58,12 @@ func Test_MeeseeksInteractions(t *testing.T) {
 			message: "args-echo hello!",
 			channel: "general",
 			expected: []expectedMessage{
-				expectedMessage{
+				{
 					TextMatcher: handshakeMatcher,
 					Channel:     "generalID",
 					IsIM:        false,
 				},
-				expectedMessage{
+				{
 					TextMatcher: "^<@myuser> .*\n```\npre-message hello!\n```$",
 					Channel:     "generalID",
 					IsIM:        false,
@@ -76,7 +76,7 @@ func Test_MeeseeksInteractions(t *testing.T) {
 			message: "unknown-command hello!",
 			channel: "general",
 			expected: []expectedMessage{
-				expectedMessage{
+				{
 					TextMatcher: "^<@myuser> Uuuh! no, I don't know how to do unknown-command$",
 					Channel:     "generalID",
 					IsIM:        false,
@@ -89,7 +89,7 @@ func Test_MeeseeksInteractions(t *testing.T) {
 			message: "",
 			channel: "general",
 			expected: []expectedMessage{
-				expectedMessage{
+				{
 					TextMatcher: "^<@myuser> Uuuh!, no, it failed :disappointed: No command to run$",
 					Channel:     "generalID",
 					IsIM:        false,
@@ -102,7 +102,7 @@ func Test_MeeseeksInteractions(t *testing.T) {
 			message: "disallowed",
 			channel: "general",
 			expected: []expectedMessage{
-				expectedMessage{
+				{
 					TextMatcher: "<@myuser> Uuuuh, yeah! you are not allowed to do disallowed",
 					Channel:     "generalID",
 					IsIM:        false,
@@ -115,12 +115,12 @@ func Test_MeeseeksInteractions(t *testing.T) {
 			message: "fail",
 			channel: "general",
 			expected: []expectedMessage{
-				expectedMessage{
+				{
 					TextMatcher: handshakeMatcher,
 					Channel:     "generalID",
 					IsIM:        false,
 				},
-				expectedMessage{
+				{
 					TextMatcher: "^<@myuser> Uuuh!, no, it failed :disappointed: exit status 1$",
 					Channel:     "generalID",
 					IsIM:        false,

--- a/meeseeks/request/parser/parser.go
+++ b/meeseeks/request/parser/parser.go
@@ -20,7 +20,7 @@ func Parse(command string) ([]string, error) {
 	state := startState
 	current := ""
 	quote := "\""
-	escapeNext := true
+	escapeNext := false
 
 	command = strings.TrimSpace(command)
 
@@ -55,7 +55,7 @@ func Parse(command string) ([]string, error) {
 			continue
 		}
 
-		if state == "arg" {
+		if state == argState {
 			if c == ' ' || c == '\t' {
 				args = append(args, current)
 				current = ""

--- a/meeseeks/request/request.go
+++ b/meeseeks/request/request.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gomeeseeks/meeseeks-box/meeseeks/message"
 	"github.com/gomeeseeks/meeseeks-box/meeseeks/request/parser"
+	"github.com/sirupsen/logrus"
 )
 
 // ErrNoCommandToRun is returned when a request can't identify a command to run
@@ -26,6 +27,8 @@ type Request struct {
 // FromMessage gets a message and generates a valid request from it
 func FromMessage(msg message.Message) (Request, error) {
 	args, err := parser.Parse(msg.GetText())
+	logrus.Debugf("Command %s parsed as %s", msg.GetText(), args)
+
 	if err != nil {
 		return Request{}, err
 	}

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -248,7 +248,7 @@ func (c *Client) Reply(content, color, channel string) error {
 	params := slack.PostMessageParameters{
 		AsUser: true,
 		Attachments: []slack.Attachment{
-			slack.Attachment{
+			{
 				Text:       content,
 				Color:      color,
 				MarkdownIn: []string{"text"},

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -142,7 +142,7 @@ func Test_ChangingTemplate(t *testing.T) {
 
 func Test_ChangingMessages(t *testing.T) {
 	templates := template.NewBuilder().WithMessages(map[string][]string{
-		template.HandshakeKey: []string{"yo!"},
+		template.HandshakeKey: {"yo!"},
 	}).Build()
 	out, err := templates.RenderHandshake("myuser")
 	stubs.Must(t, "can't render changed handshake tempalte", err)


### PR DESCRIPTION
This PR implements aliases, a handy shortcut for complex commands.

This works pretty much the same way as a shell: `alias` sets an alias, `unalias` remove it and `aliases` shows all the aliases. It's important to note that aliases are scoped by user. This means a user can only see its own aliases and more users can share the same alias.

Now for the techy details. Aliases are stored in a new Bolt bucket called `aliases` and each user id has its own sub-bucket. Then each alias is stored as a key in this bucket. When a user deletes the last alias then the user sub-bucket also gets deleted: auto-cleanup.

This is still WIP as tests are completely missing.

Closes #21.