### PR TITLE
Add stealth mode

### DIFF
--- a/auth/groups.go
+++ b/auth/groups.go
@@ -11,6 +11,7 @@ type Groups struct {
 }
 
 var groups *Groups
+var knownUsers map[string]struct{}
 
 // Errors
 var (
@@ -25,11 +26,13 @@ func Configure(configuredGroups map[string][]string) {
 	g := Groups{
 		groups: map[string]map[string]bool{},
 	}
+	knownUsers = make(map[string]struct{})
 
 	for name, users := range configuredGroups {
 		group := make(map[string]bool)
 		for _, user := range users {
 			group[user] = true
+			knownUsers[user] = struct{}{}
 		}
 		g.groups[name] = group
 	}
@@ -61,4 +64,10 @@ func GetGroups() map[string][]string {
 		g[group] = groupUsers
 	}
 	return g
+}
+
+// IsKnownUser returns true if the user is configured in any group
+func IsKnownUser(username string) (ok bool) {
+	_, ok = knownUsers[username]
+	return
 }

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 	showVersion := flag.Bool("version", false, "print the version and exit")
 	apiAddress := flag.String("api-endpoint", ":9696", "api endpoint in which to listen for api calls")
 	apiPath := flag.String("api-path", "/message", "api path in to listen for api calls")
+	slackStealth := flag.Bool("stealth", false, "Enable slack stealth mode")
 
 	flag.Parse()
 
@@ -47,7 +48,12 @@ func main() {
 
 	log.Info("Loaded configuration")
 
-	slackClient, err := slack.Connect(*debugSlack, os.Getenv("SLACK_TOKEN"))
+	slackClient, err := slack.Connect(
+		slack.ConnectionOpts{
+			Debug:   *debugSlack,
+			Token:   os.Getenv("SLACK_TOKEN"),
+			Stealth: *slackStealth,
+		})
 	if err != nil {
 		log.Fatalf("Could not connect to slack: %s", err)
 	}

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -105,6 +105,7 @@ func Connect(opts ConnectionOpts) (*Client, error) {
 	go rtm.ManageConnection()
 
 	if opts.Stealth {
+		logrus.Info("Running in stealth mode")
 		rtm.SetUserPresence("away")
 	}
 
@@ -203,8 +204,8 @@ func (m *messageMatcher) shouldCare(message *slack.MessageEvent) (string, bool) 
 		return "", false
 	}
 	if m.shouldIgnoreUser(message.User) {
-		logrus.Debug("Received message from unknown user %s while in stealth mode, ignoring",
-			m.getUser(message.User))
+		logrus.Debugf("Received message '%s' from unknown user %s while in stealth mode, ignoring",
+			message.Text, m.getUser(message.User))
 		return "", false
 	}
 	if m.isIMChannel(message.Channel) {

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gomeeseeks/meeseeks-box/auth"
 	"github.com/gomeeseeks/meeseeks-box/meeseeks/message"
 	"github.com/sirupsen/logrus"
 
@@ -76,14 +77,21 @@ func (c Client) IsIM(channelID string) bool {
 	return c.matcher.isIMChannel(channelID)
 }
 
+// ConnectionOpts groups all the conection options in a single struct
+type ConnectionOpts struct {
+	Debug   bool
+	Token   string
+	Stealth bool
+}
+
 // Connect builds a new chat client
-func Connect(debug bool, token string) (*Client, error) {
-	if token == "" {
+func Connect(opts ConnectionOpts) (*Client, error) {
+	if opts.Token == "" {
 		return nil, fmt.Errorf("could not connect to slack: SLACK_TOKEN env var is empty")
 	}
 
-	slackClient := slack.New(token)
-	slackClient.SetDebug(debug)
+	slackClient := slack.New(opts.Token)
+	slackClient.SetDebug(opts.Debug)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -96,10 +104,14 @@ func Connect(debug bool, token string) (*Client, error) {
 	rtm := slackClient.NewRTM()
 	go rtm.ManageConnection()
 
+	if opts.Stealth {
+		rtm.SetUserPresence("away")
+	}
+
 	return &Client{
 		apiClient: slackClient,
 		rtm:       rtm,
-		matcher:   newMessageMatcher(rtm),
+		matcher:   newMessageMatcher(rtm, opts.Stealth),
 	}, nil
 }
 
@@ -107,11 +119,13 @@ type messageMatcher struct {
 	botID         string
 	prefixMatches []string
 	rtm           *slack.RTM
+	stealth       bool
 }
 
-func newMessageMatcher(rtm *slack.RTM) messageMatcher {
+func newMessageMatcher(rtm *slack.RTM, stealth bool) messageMatcher {
 	return messageMatcher{
-		rtm: rtm,
+		rtm:     rtm,
+		stealth: stealth,
 	}
 }
 
@@ -127,6 +141,13 @@ func (m *messageMatcher) getUser(userID string) string {
 
 func (m *messageMatcher) isIMChannel(channel string) bool {
 	return strings.HasPrefix(channel, "D")
+}
+
+func (m *messageMatcher) shouldIgnoreUser(userID string) bool {
+	if m.stealth {
+		return !auth.IsKnownUser(m.getUser(userID))
+	}
+	return false
 }
 
 // GetChannel returns a channel name given an ID
@@ -179,6 +200,11 @@ func (m *messageMatcher) isMyself(message *slack.MessageEvent) bool {
 func (m *messageMatcher) shouldCare(message *slack.MessageEvent) (string, bool) {
 	if m.isMyself(message) {
 		logrus.Debug("It's myself, ignoring message")
+		return "", false
+	}
+	if m.shouldIgnoreUser(message.User) {
+		logrus.Debug("Received message from unknown user %s while in stealth mode, ignoring",
+			m.getUser(message.User))
 		return "", false
 	}
 	if m.isIMChannel(message.Channel) {


### PR DESCRIPTION
This PR adds a stealth mode.

To enable this mode it is necessary to pass `-stealth` to the executable when launching.

In this mode, the bot will get online and immediately it will set itself to be _away_, which makes it look like being offline.

On top of this, the bot will only reply to messages sent by _known users_. These users are those that are included in any group in the configuration, the rest will simply be ignored, again, making it look like it is offline.