### PR TITLE
Make tail behave like unix tail, it only returns the last N lines

### DIFF
--- a/commands/builtins/builtins.go
+++ b/commands/builtins/builtins.go
@@ -619,6 +619,7 @@ type tailCommand struct {
 
 func (t tailCommand) Execute(_ context.Context, job jobs.Job) (string, error) {
 	flags := flag.NewFlagSet("tail", flag.ContinueOnError)
+	limit := flags.Int("limit", 5, "how many lines to return")
 
 	flags.Parse(job.Request.Args)
 
@@ -631,7 +632,7 @@ func (t tailCommand) Execute(_ context.Context, job jobs.Job) (string, error) {
 		return "", err
 	}
 
-	jobLogs, err := logs.Get(jobID)
+	jobLogs, err := logs.Tail(jobID, *limit)
 	if err != nil {
 		return "", err
 	}

--- a/commands/builtins/builtins_test.go
+++ b/commands/builtins/builtins_test.go
@@ -322,25 +322,56 @@ func Test_BuiltinCommands(t *testing.T) {
 			expected: "* *ID* 1\n* *Status* Running\n* *Command* command\n* *Args* \"arg1\" \"arg2\" \n* *Where* <#123>\n* *When* now\n",
 		},
 		{
-			name: "test tail command",
+			name: "test tail command with jobID",
 			req: request.Request{
 				Command: builtins.BuiltinTailCommand,
-				UserID:  "userid",
+				UserID:  "someone",
 			},
-
 			job: jobs.Job{
-				Request: request.Request{Username: "someone"},
+				Request: request.Request{
+					Username: "someone",
+					Args:     []string{"-limit", "1", "1"}},
 			},
 			setup: func() {
 				j, err := jobs.Create(req)
 				stubs.Must(t, "create job", err)
-				logs.Append(j.ID, "something to say 1")
+				logs.Append(j.ID, "line 1.1")
+				logs.Append(j.ID, "line 1.2")
+				logs.Append(j.ID, "line 1.3")
+				logs.Append(j.ID, "line 1.4")
 
 				j, err = jobs.Create(req)
 				stubs.Must(t, "create job", err)
-				logs.Append(j.ID, "something to say 2")
+				logs.Append(j.ID, "line 2.1")
+				logs.Append(j.ID, "line 2.2")
+				logs.Append(j.ID, "line 2.3")
 			},
-			expected: "something to say 2",
+			expected: "line 1.4",
+		},
+		{
+			name: "test tail command",
+			req: request.Request{
+				Command: builtins.BuiltinTailCommand,
+				UserID:  "someone",
+			},
+
+			job: jobs.Job{
+				Request: request.Request{Username: "someone", Args: []string{"-limit", "2"}},
+			},
+			setup: func() {
+				j, err := jobs.Create(req)
+				stubs.Must(t, "create job", err)
+				logs.Append(j.ID, "line 1.1")
+				logs.Append(j.ID, "line 1.2")
+				logs.Append(j.ID, "line 1.3")
+
+				j, err = jobs.Create(req)
+				stubs.Must(t, "create job", err)
+				logs.Append(j.ID, "line 2.1")
+				logs.Append(j.ID, "line 2.2")
+				logs.Append(j.ID, "line 2.3")
+			},
+			expected: "line 2.2\nline 2.3",
 		},
 		{
 			name: "test head command",
@@ -358,11 +389,35 @@ func Test_BuiltinCommands(t *testing.T) {
 
 				j, err = jobs.Create(req)
 				stubs.Must(t, "create job", err)
-				logs.Append(j.ID, "line 2.1\n")
-				logs.Append(j.ID, "line 2.2\n")
-				logs.Append(j.ID, "something to say 2\n")
+				logs.Append(j.ID, "line 2.1")
+				logs.Append(j.ID, "line 2.2")
+				logs.Append(j.ID, "something to say 2")
 			},
-			expected: "line 2.1\nline 2.2\n",
+			expected: "line 2.1\nline 2.2",
+		},
+		{
+			name: "test head command with jobID",
+			req: request.Request{
+				Command: builtins.BuiltinHeadCommand,
+				UserID:  "userid",
+			},
+			job: jobs.Job{
+				Request: request.Request{Username: "someone", Args: []string{"-limit", "1", "1"}},
+			},
+			setup: func() {
+				j, err := jobs.Create(req)
+				stubs.Must(t, "create job", err)
+				logs.Append(j.ID, "line 1.1")
+				logs.Append(j.ID, "line 1.2")
+				logs.Append(j.ID, "something to say 1")
+
+				j, err = jobs.Create(req)
+				stubs.Must(t, "create job", err)
+				logs.Append(j.ID, "line 2.1")
+				logs.Append(j.ID, "line 2.2")
+				logs.Append(j.ID, "something to say 2")
+			},
+			expected: "line 1.1",
 		},
 		{
 			name: "test logs command",
@@ -483,9 +538,10 @@ func Test_BuiltinCommands(t *testing.T) {
 				Command: builtins.BuiltinCancelJobCommand,
 				UserID:  "userid",
 			},
-
 			job: jobs.Job{
-				Request: request.Request{Username: "someone_else", Args: []string{"2"}},
+				Request: request.Request{Username: "someone_else",
+					Args: []string{"2"},
+				},
 			},
 			setup: func() {
 				_, err := jobs.Create(req)

--- a/jobs/logs/logs_test.go
+++ b/jobs/logs/logs_test.go
@@ -28,7 +28,7 @@ func Test_Logs(t *testing.T) {
 		{
 			name:  "with multiple lines",
 			jobID: 2,
-			logs:  []string{"something", "\n", "something else"},
+			logs:  []string{"something", "something else"},
 			err:   nil,
 			expected: logs.JobLog{
 				Output: "something\nsomething else",


### PR DESCRIPTION
This is one ready to be merged on top of the head command, as it builds on top of that one.

This PR implements tail like unix tail by only returning the last N lines of the logs.

It also supports returning the last job if no jobID is passed in automagically, or the one passed in.

It is symmetric to the head command.