### PR TITLE
Add full API token lifecycle test

### DIFF
--- a/commands/builtins/builtins_test.go
+++ b/commands/builtins/builtins_test.go
@@ -3,6 +3,7 @@ package builtins_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/gomeeseeks/meeseeks-box/aliases"
@@ -553,5 +554,63 @@ func Test_FilterJobsAudit(t *testing.T) {
 			t.Fatalf("Failed to execute audit: %s", err)
 		}
 		stubs.AssertEquals(t, "*4* - now - *command* by *someone* in *<#123>* - *Running*\n*3* - now - *command* by *someone* in *<#123>* - *Running*\n", limit)
+	}))
+}
+
+func TestAPITokenLifecycle(t *testing.T) {
+
+	exec := func(r request.Request) (string, error) {
+		cmd, ok := commands.Find(&r)
+		if !ok {
+			t.Fatalf("could not find command %s", r.Command)
+		}
+
+		return cmd.Execute(context.Background(), jobs.NullJob(r))
+	}
+
+	stubs.Must(t, "failed to audit the correct jobs", stubs.WithTmpDB(func(_ string) {
+
+		out, err := exec(request.Request{
+			Command: builtins.BuiltinListAPITokenCommand,
+			UserID:  "apiuser",
+			IsIM:    true,
+		})
+		stubs.Must(t, "can't list api tokens:", err)
+		stubs.AssertEquals(t, "No tokens could be found", out)
+
+		out, err = exec(request.Request{
+			Command: builtins.BuiltinNewAPITokenCommand,
+			UserID:  "apiuser",
+			IsIM:    true,
+			Args:    []string{"apiuser", "yolo", "rm", "-rf"},
+		})
+		stubs.Must(t, "can't create an api token:", err)
+
+		token := strings.Split(out, " ")[2]
+
+		out, err = exec(request.Request{
+			Command: builtins.BuiltinListAPITokenCommand,
+			UserID:  "apiuser",
+			IsIM:    true,
+		})
+		stubs.Must(t, "can't list api tokens:", err)
+		stubs.AssertEquals(t, fmt.Sprintf("- *%s* apiuser at yolo _rm -rf_\n", token), out)
+
+		out, err = exec(request.Request{
+			Command: builtins.BuiltinRevokeAPITokenCommand,
+			UserID:  "apiuser",
+			IsIM:    true,
+			Args:    []string{token},
+		})
+		stubs.Must(t, "can't revoke an api token:", err)
+		stubs.AssertEquals(t, fmt.Sprintf("Token *%s* has been revoked", token), out)
+
+		out, err = exec(request.Request{
+			Command: builtins.BuiltinListAPITokenCommand,
+			UserID:  "apiuser",
+			IsIM:    true,
+		})
+		stubs.Must(t, "can't list api tokens:", err)
+		stubs.AssertEquals(t, "No tokens could be found", out)
 	}))
 }

--- a/db/db.go
+++ b/db/db.go
@@ -55,6 +55,9 @@ func IDFromBytes(ID []byte) uint64 {
 
 // WithDB invokes the passed function with a valid DB object
 func WithDB(f func(db *bolt.DB) error) error {
+	if database == nil {
+		return fmt.Errorf("database is not initialized")
+	}
 	return f(database)
 }
 


### PR DESCRIPTION
In this PR we add a test that exercises the whole API token lifecycle listing when there is no token, creating one, listing again and checking that it's there, then revoking and then listing one last time to ensure that we are back at 0.

Additionally, this PR makes the DB layer return an error when there is no DB defined (not initialized) to make it fail correctly instead of blowing because of a nil pointer access.