### PR TITLE
Don't buffer logs

### DIFF
--- a/commands/shell/shell_test.go
+++ b/commands/shell/shell_test.go
@@ -45,7 +45,7 @@ func TestExecuteEcho(t *testing.T) {
 			Request: meeseeks.Request{Args: []string{"hello", "meeseeks\nsecond line"}},
 		})
 		mocks.Must(t, "failed to execute echo command", err)
-		mocks.AssertEquals(t, "hello meeseeks\nsecond line\n", out)
+		mocks.AssertEquals(t, "hello meeseeks\nsecond line", out)
 	})
 }
 

--- a/meeseeks/executor/executor_test.go
+++ b/meeseeks/executor/executor_test.go
@@ -43,7 +43,7 @@ func Test_MeeseeksInteractions(t *testing.T) {
 					IsIM:        false,
 				},
 				{
-					TextMatcher: "^<@myuser> .*\n```\nhello!\n```$",
+					TextMatcher: "^<@myuser> .*\n```\nhello!```$",
 					Channel:     "generalID",
 					IsIM:        false,
 				},
@@ -61,7 +61,7 @@ func Test_MeeseeksInteractions(t *testing.T) {
 					IsIM:        false,
 				},
 				{
-					TextMatcher: "^<@myuser> .*\n```\npre-message hello!\n```$",
+					TextMatcher: "^<@myuser> .*\n```\npre-message hello!```$",
 					Channel:     "generalID",
 					IsIM:        false,
 				},


### PR DESCRIPTION
This saves memory (because we don't need to keep those buffers loaded), simplifies the execution, and also removes a weird case in which the result of the execution differs in a last `\n` from getting back the logs from the DB.

It's also preparatory to handle remote logs.