### PR TITLE
Update slack and use connect instead of start

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,7 +20,6 @@
   version = "v1.2.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/nlopes/slack"
   packages = ["."]
   revision = "1217b9d3e4304348a9be15c2afd80ad4691f31e5"
@@ -58,6 +57,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "18afd8a4d54345ca1a43100e88224832f817f9c543da335d00380d7708ec5e14"
+  inputs-digest = "8608a72501aab2b66252609452817c7e9b156b25c153f8b590c1739ca558a987"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,10 +20,10 @@
   version = "v1.2.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/nlopes/slack"
   packages = ["."]
-  revision = "8ab4d0b364ef1e9af5d102531da20d5ec902b6c4"
-  version = "v0.2.0"
+  revision = "1217b9d3e4304348a9be15c2afd80ad4691f31e5"
 
 [[projects]]
   name = "github.com/renstrom/dedent"
@@ -41,23 +41,23 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "0fcca4842a8d74bfddc2c96a073bd2a4d2a7a2e8"
+  revision = "91a49db82a88618983a78a06c1cbd4e00ab749ab"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "83801418e1b59fb1880e363299581ee543af32ca"
+  revision = "dd2ff4accc098aceecb86b36eaa7829b2a17b1c9"
 
 [[projects]]
-  branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "287cf08546ab5e7e37d55a84f7ed3fd1db036de5"
+  revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
+  version = "v2.1.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "76ae5da3a21b8ca9bbf64d1d7083700a1ee43a9be490d48cdfec2df8736c3610"
+  inputs-digest = "18afd8a4d54345ca1a43100e88224832f817f9c543da335d00380d7708ec5e14"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,5 +27,6 @@
 
 [[constraint]]
   name = "github.com/nlopes/slack"
-  branch = "master"
+  # branch = "master"
   # version = "0.2.0"
+  revision = "1217b9d3e4304348a9be15c2afd80ad4691f31e5"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,4 +27,5 @@
 
 [[constraint]]
   name = "github.com/nlopes/slack"
-  version = "0.2.0"
+  branch = "master"
+  # version = "0.2.0"

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -115,7 +115,7 @@ func Connect(opts ConnectionOpts) (*Client, error) {
 		return nil, fmt.Errorf("could not connect to slack: %s", err)
 	}
 
-	rtm := slackClient.NewRTM(slack.RTMOptionUseStart(true))
+	rtm := slackClient.NewRTM(slack.RTMOptionUseStart(false))
 	go rtm.ManageConnection()
 
 	if opts.Stealth {

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -115,7 +115,7 @@ func Connect(opts ConnectionOpts) (*Client, error) {
 		return nil, fmt.Errorf("could not connect to slack: %s", err)
 	}
 
-	rtm := slackClient.NewRTM()
+	rtm := slackClient.NewRTM(slack.RTMOptionUseStart(false))
 	go rtm.ManageConnection()
 
 	if opts.Stealth {

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -115,7 +115,7 @@ func Connect(opts ConnectionOpts) (*Client, error) {
 		return nil, fmt.Errorf("could not connect to slack: %s", err)
 	}
 
-	rtm := slackClient.NewRTM(slack.RTMOptionUseStart(false))
+	rtm := slackClient.NewRTM(slack.RTMOptionUseStart(true))
 	go rtm.ManageConnection()
 
 	if opts.Stealth {


### PR DESCRIPTION
This is something that is impacting me in my local network where for some reason websocket.Start locks forever, whereas websocket.Connect works just fine.

I had to update dependencies and I have also sent a PR to Gorilla/WebSockets (https://github.com/gorilla/websocket/pull/356) to add handshake timeouts so at least it fails and retries.

I've created a snapshot and uploaded it to docker as _latest_ to test that it actually works, you can check it in slack.