### PR TITLE
Allow disabling the handshake when configuring a command

### DIFF
--- a/commands/shell/shell.go
+++ b/commands/shell/shell.go
@@ -20,6 +20,7 @@ type CommandOpts struct {
 	AllowedGroups   []string
 	AllowedChannels []string
 	AuthStrategy    string
+	HasHandshake    bool
 	Timeout         time.Duration
 	Templates       map[string]string
 	Help            meeseeks.Help
@@ -101,7 +102,7 @@ func (c shellCommand) Execute(ctx context.Context, job meeseeks.Job) (string, er
 }
 
 func (c shellCommand) HasHandshake() bool {
-	return true
+	return c.opts.HasHandshake
 }
 
 func (c shellCommand) Templates() map[string]string {

--- a/commands/shell/shell_test.go
+++ b/commands/shell/shell_test.go
@@ -31,7 +31,7 @@ func TestShellCommand(t *testing.T) {
 	mocks.AssertEquals(t, []string{}, echoCommand.Args())
 	mocks.AssertEquals(t, []string{}, echoCommand.AllowedGroups())
 	mocks.AssertEquals(t, []string{}, echoCommand.AllowedChannels())
-	mocks.AssertEquals(t, true, echoCommand.HasHandshake())
+	mocks.AssertEquals(t, false, echoCommand.HasHandshake())
 	mocks.AssertEquals(t, true, echoCommand.Record())
 	mocks.AssertEquals(t, map[string]string{}, echoCommand.Templates())
 	mocks.AssertEquals(t, meeseeks.DefaultCommandTimeout, echoCommand.Timeout())

--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,7 @@ func LoadConfig(cnf Config) error {
 			AllowedChannels: cmd.AllowedChannels,
 			Args:            cmd.Args,
 			AuthStrategy:    cmd.AuthStrategy,
+			HasHandshake:    !cmd.NoHandshake,
 			Cmd:             cmd.Cmd,
 			Help: shell.NewHelp(
 				cmd.Help.Summary,
@@ -112,6 +113,7 @@ type Command struct {
 	AllowedGroups   []string          `yaml:"allowed_groups"`
 	AllowedChannels []string          `yaml:"allowed_channels"`
 	AuthStrategy    string            `yaml:"auth_strategy"`
+	NoHandshake     bool              `yaml:"no_handshake"`
 	Timeout         time.Duration     `yaml:"timeout"`
 	Templates       map[string]string `yaml:"templates"`
 	Help            CommandHelp       `yaml:"help"`


### PR DESCRIPTION
This way we can reduce the amount of noise it would generate in a crowded chat.

By default, it will still reply with a handshake, but by setting `no_handshake: true` meeseeks will stop replying immediately to acknowledge a command.