### PR TITLE
Change casing of error messages to be lowercase all around

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -31,8 +31,14 @@ var ErrUserNotAllowed = errors.New("user no allowed")
 // ErrChannelNotAllowed is the error returne when the auth check fails because the command was invoked in a not allowed channel
 var ErrChannelNotAllowed = errors.New("command not allowed in channel")
 
-// ErrOnlyIMAllowed is the error returne when the auth check fails because the command was invoked on a public channel
-var ErrOnlyIMAllowed = errors.New("Command only allowed in IM")
+// ErrOnlyIMAllowed is the error returned when the auth check fails because the command was invoked on a public channel
+var ErrOnlyIMAllowed = errors.New("command only allowed in IM")
+
+// ErrGroupNotFound is the error returned when we authorize a group that is not defined
+var ErrGroupNotFound = fmt.Errorf("groups does not exists")
+
+// ErrUserNotInGroup is the error returned when a user does not belong to a given group
+var ErrUserNotInGroup = fmt.Errorf("user does not belong to group")
 
 // Authorization Strategies determine who has access to what
 const (
@@ -127,12 +133,6 @@ type Groups struct {
 
 var groups *Groups
 var knownUsers map[string]struct{}
-
-// Errors
-var (
-	ErrGroupNotFound  = fmt.Errorf("Groups does not exists")
-	ErrUserNotInGroup = fmt.Errorf("User does not belong to group")
-)
 
 // Configure loads all the configured groups
 //

--- a/commands/builtins/builtins.go
+++ b/commands/builtins/builtins.go
@@ -388,10 +388,10 @@ func (h helpCommand) Execute(_ context.Context, job meeseeks.Job) (string, error
 				"help": cmd.Help(),
 			})
 		}
-		return "", fmt.Errorf("Could not find command %s", flags.Arg(0))
+		return "", fmt.Errorf("could not find command %s", flags.Arg(0))
 
 	default:
-		return "", fmt.Errorf("Too many arguments")
+		return "", fmt.Errorf("too many arguments")
 	}
 }
 
@@ -637,7 +637,7 @@ func (l lastCommand) Execute(_ context.Context, job meeseeks.Job) (string, error
 		return "", fmt.Errorf("failed to get the last job: %s", err)
 	}
 	if len(jobs) == 0 {
-		return "", fmt.Errorf("No last command for current user")
+		return "", fmt.Errorf("no last command for current user")
 	}
 	tmpl, err := template.New("job", jobTemplate)
 	if err != nil {
@@ -677,7 +677,7 @@ func (l findJobCommand) Execute(_ context.Context, job meeseeks.Job) (string, er
 		return "", fmt.Errorf("failed to get the last job: %s", err)
 	}
 	if len(jobs) == 0 {
-		return "", fmt.Errorf("No last command for current user")
+		return "", fmt.Errorf("no last command for current user")
 	}
 
 	tmpl, err := template.New("job", jobTemplate)
@@ -715,7 +715,7 @@ func (l auditJobCommand) Execute(_ context.Context, job meeseeks.Job) (string, e
 		return "", fmt.Errorf("failed to get job %d: %s", job.ID, err)
 	}
 	if len(jobs) == 0 {
-		return "", fmt.Errorf("Job not found")
+		return "", fmt.Errorf("job not found")
 	}
 
 	tmpl, err := template.New("job", jobTemplate)
@@ -862,7 +862,7 @@ func (t logsCommand) Execute(_ context.Context, job meeseeks.Job) (string, error
 		return "", fmt.Errorf("failed to find job with id %d: %s", id, err)
 	}
 	if len(jobs) == 0 {
-		return "", fmt.Errorf("No job with id %d for user %s", id, callingUser)
+		return "", fmt.Errorf("no job with id %d for user %s", id, callingUser)
 	}
 	j := jobs[0]
 
@@ -1100,7 +1100,7 @@ func findLastJobIDForUser(callingUser string) (uint64, error) {
 		return 0, fmt.Errorf("failed to get the last job: %s", err)
 	}
 	if len(jobs) == 0 {
-		return 0, fmt.Errorf("No last command for current user")
+		return 0, fmt.Errorf("no last command for current user")
 	}
 	return jobs[0].ID, nil
 

--- a/commands/shell/shell.go
+++ b/commands/shell/shell.go
@@ -48,12 +48,12 @@ func (c shellCommand) Execute(ctx context.Context, job meeseeks.Job) (string, er
 
 	AppendLogs := func(line string) {
 		if e := logs.Append(job.ID, line); e != nil {
-			logrus.Errorf("Could not append '%s' to job %d logs: %s", line, job.ID, e)
+			logrus.Errorf("could not append '%s' to job %d logs: %s", line, job.ID, e)
 		}
 	}
 	SetError := func(err error) error {
 		if e := logs.SetError(job.ID, err); e != nil {
-			logrus.Errorf("Could set error to job %d: %s", job.ID, e)
+			logrus.Errorf("could set error to job %d: %s", job.ID, e)
 		}
 		return err
 	}
@@ -61,11 +61,11 @@ func (c shellCommand) Execute(ctx context.Context, job meeseeks.Job) (string, er
 	cmd := exec.CommandContext(ctx, c.Cmd(), cmdArgs...)
 	op, err := cmd.StdoutPipe()
 	if err != nil {
-		return "", SetError(fmt.Errorf("Could not create stdout pipe: %s", err))
+		return "", SetError(fmt.Errorf("could not create stdout pipe: %s", err))
 	}
 	ep, err := cmd.StderrPipe()
 	if err != nil {
-		return "", SetError(fmt.Errorf("Could not create stderr pipe: %s", err))
+		return "", SetError(fmt.Errorf("could not create stderr pipe: %s", err))
 	}
 
 	tr := io.MultiReader(op, ep)
@@ -82,7 +82,7 @@ func (c shellCommand) Execute(ctx context.Context, job meeseeks.Job) (string, er
 
 	err = cmd.Start()
 	if err != nil {
-		logrus.Errorf("Command failed to start: %s", err)
+		logrus.Errorf("command failed to start: %s", err)
 		return "", SetError(err)
 	}
 
@@ -90,13 +90,13 @@ func (c shellCommand) Execute(ctx context.Context, job meeseeks.Job) (string, er
 
 	err = cmd.Wait()
 	if err != nil {
-		logrus.Errorf("Command failed: %s", err)
+		logrus.Errorf("command failed: %s", err)
 		return "", SetError(err)
 	}
 
 	jobLog, err := logs.Get(job.ID)
 	if err != nil {
-		logrus.Errorf("Failed to read back output for job %d: %s", job.ID, err)
+		logrus.Errorf("failed to read back output for job %d: %s", job.ID, err)
 	}
 
 	return jobLog.Output, jobLog.GetError()

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -154,7 +154,7 @@ func (r Reply) Render() (string, error) {
 	case template.Success:
 		return r.templates.Build().RenderSuccess(r.to.UserLink, r.output)
 	default:
-		return "", fmt.Errorf("Don't know how to render mode '%s'", r.mode)
+		return "", fmt.Errorf("don't know how to render mode '%s'", r.mode)
 	}
 }
 

--- a/jobs/logs/logs.go
+++ b/jobs/logs/logs.go
@@ -16,7 +16,7 @@ var logsBucketKey = []byte("logs")
 var errorKey = []byte("error")
 
 // ErrNoLogsForJob is returned when we try to extract the logs of a non existing job
-var ErrNoLogsForJob = errors.New("No logs for job")
+var ErrNoLogsForJob = errors.New("no logs for job")
 
 // Append adds a new line to the logs of the given Job
 func Append(jobID uint64, content string) error {

--- a/meeseeks/executor/executor_test.go
+++ b/meeseeks/executor/executor_test.go
@@ -87,7 +87,7 @@ func Test_MeeseeksInteractions(t *testing.T) {
 			channel: "general",
 			expected: []expectedMessage{
 				{
-					TextMatcher: "^<@myuser> Uuuh!, no, it failed :disappointed: No command to run$",
+					TextMatcher: "^<@myuser> Uuuh!, no, it failed :disappointed: no command to run$",
 					Channel:     "generalID",
 					IsIM:        false,
 				},

--- a/meeseeks/request/parser/parser.go
+++ b/meeseeks/request/parser/parser.go
@@ -12,7 +12,7 @@ const (
 )
 
 // ErrUnclosedQuoteInCommand means that the command is not correctly escaped
-var ErrUnclosedQuoteInCommand = errors.New("Unclosed quote on command")
+var ErrUnclosedQuoteInCommand = errors.New("unclosed quote on command")
 
 // Parse parses a command and returns a slice of strings and an error if the command is wrongly built
 func Parse(command string) ([]string, error) {

--- a/meeseeks/request/request.go
+++ b/meeseeks/request/request.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ErrNoCommandToRun is returned when a request can't identify a command to run
-var ErrNoCommandToRun = errors.New("No command to run")
+var ErrNoCommandToRun = errors.New("no command to run")
 
 // FromMessage gets a message and generates a valid request from it
 func FromMessage(msg meeseeks.Message) (meeseeks.Request, error) {

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var errIgnoredMessage = fmt.Errorf("Ignore this message")
+var errIgnoredMessage = fmt.Errorf("ignore this message")
 
 const (
 	textStyle = "text"

--- a/template/template.go
+++ b/template/template.go
@@ -184,11 +184,11 @@ type Payload map[string]interface{}
 func anyValue(key string, payload map[string]interface{}) (string, error) {
 	values, ok := payload[key]
 	if !ok {
-		return "", fmt.Errorf("ERROR: %s is not loaded in the payload", key)
+		return "", fmt.Errorf("%s is not loaded in the payload", key)
 	}
 	slice, ok := values.([]string)
 	if !ok {
-		return "", fmt.Errorf("ERROR: %s is not a string slice", key)
+		return "", fmt.Errorf("%s is not a string slice", key)
 	}
 	return slice[rand.Intn(len(slice))], nil
 }

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -104,13 +104,13 @@ func Test_InvalidData(t *testing.T) {
 			name:     "no value",
 			template: "{{ AnyValue \"Value\" . }}",
 			payload:  template.Payload{},
-			expected: "failed to execute template no value: template: no value:1:3: executing \"no value\" at <AnyValue \"Value\" .>: error calling AnyValue: ERROR: Value is not loaded in the payload",
+			expected: "failed to execute template no value: template: no value:1:3: executing \"no value\" at <AnyValue \"Value\" .>: error calling AnyValue: Value is not loaded in the payload",
 		},
 		{
 			name:     "wrong value type",
 			template: "{{ AnyValue \"Value\" . }}",
 			payload:  template.Payload{"Value": "something"},
-			expected: "failed to execute template wrong value type: template: wrong value type:1:3: executing \"wrong value type\" at <AnyValue \"Value\" .>: error calling AnyValue: ERROR: Value is not a string slice",
+			expected: "failed to execute template wrong value type: template: wrong value type:1:3: executing \"wrong value type\" at <AnyValue \"Value\" .>: error calling AnyValue: Value is not a string slice",
 		},
 	}
 	for _, tc := range tt {


### PR DESCRIPTION
This way we are consistent with idiomatic Go, and it looks better when we are concatenating things.