### PR TITLE
Add boot time metric

### DIFF
--- a/meeseeks/metrics/metrics.go
+++ b/meeseeks/metrics/metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"time"
 )
 
 var namespace = "meeseeks"
@@ -63,7 +64,15 @@ var LogLinesCount = prometheus.NewCounter(prometheus.CounterOpts{
 	Help:      "Count of lines that have been written to the log",
 })
 
+var bootTime = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: namespace,
+	Name:      "boot_time_seconds",
+	Help:      "unix timestamp of when the meeseeks process was started",
+})
+
 func init() {
+	bootTime.Set(float64(time.Now().Unix()))
+
 	prometheus.MustRegister(ReceivedCommandsCount)
 	prometheus.MustRegister(UnknownCommandsCount)
 	prometheus.MustRegister(RejectedCommandsCount)
@@ -72,4 +81,5 @@ func init() {
 	prometheus.MustRegister(SuccessfulTasksCount)
 	prometheus.MustRegister(TaskDurations)
 	prometheus.MustRegister(LogLinesCount)
+	prometheus.MustRegister(bootTime)
 }


### PR DESCRIPTION
Closes https://github.com/gomeeseeks/meeseeks-box/issues/29

it implements a single `meeseeks_boot_time_seconds` metric that accounts for the Unix timestamp (seconds since 1970-01-01)  which can be used to calculate the uptime by issuing `time() - meeseeks_boot_time_seconds`