### PR TITLE
Fix metrics cmd leak

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gomeeseeks/meeseeks-box/aliases"
 	"github.com/gomeeseeks/meeseeks-box/commands/builtins"
 	"github.com/gomeeseeks/meeseeks-box/meeseeks"
+	"github.com/gomeeseeks/meeseeks-box/meeseeks/metrics"
 	"github.com/sirupsen/logrus"
 )
 
@@ -48,7 +49,9 @@ func Find(req *meeseeks.Request) (meeseeks.Command, bool) {
 	}
 
 	if cmd, ok := commands[aliasedCommand]; ok {
-		logrus.Infof("Command %s is an alias", req.Command)
+		logrus.Infof("Command %s is an alias for %s", req.Command, aliasedCommand)
+		metrics.AliasedCommandsCount.Inc()
+		req.Command = aliasedCommand
 		req.Args = append(args, req.Args...)
 
 		return cmd, ok

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -113,7 +113,7 @@ func Finish(jobID uint64, status string) error {
 		job.Status = status
 
 		difference := job.EndTime.Sub(job.StartTime)
-		metrics.TaskDurations.Observe(difference.Seconds())
+		metrics.TaskDurations.WithLabelValues(job.Request.Command).Observe(difference.Seconds())
 
 		return save(job, bucket)
 	})

--- a/meeseeks/executor/executor.go
+++ b/meeseeks/executor/executor.go
@@ -89,13 +89,13 @@ func (m *Meeseeks) Start() {
 				UserLink:  msg.GetUserLink(),
 				ChannelID: msg.GetChannelID(),
 			}, req.Command).WithCommand(cmd))
-			metrics.RejectedCommandsCount.WithLabelValues(cmd.Cmd()).Inc()
+			metrics.RejectedCommandsCount.WithLabelValues(req.Command).Inc()
 			continue
 		}
 
 		logrus.Infof("Accepted command '%s' from user '%s' on channel '%s' with args: %s",
 			req.Command, req.Username, req.Channel, req.Args)
-		metrics.AcceptedCommandsCount.WithLabelValues(cmd.Cmd()).Inc()
+		metrics.AcceptedCommandsCount.WithLabelValues(req.Command).Inc()
 
 		t, err := m.createTask(req, cmd)
 		if err != nil {

--- a/meeseeks/metrics/metrics.go
+++ b/meeseeks/metrics/metrics.go
@@ -50,12 +50,12 @@ var SuccessfulTasksCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 }, []string{"command"})
 
 // TaskDurations provides buckets to observe task execution latencies
-var TaskDurations = prometheus.NewHistogram(prometheus.HistogramOpts{
+var TaskDurations = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Namespace: namespace,
 	Name:      "tasks_durations_seconds",
 	Buckets:   prometheus.ExponentialBuckets(0.00025, 2, 18), // exponential buckets, starting at 0.25ms up to over 1h,
 	Help:      "Command execution time distributions in seconds.",
-})
+}, []string{"command"})
 
 // LogLinesCount is the count of tasks that have been accepted
 var LogLinesCount = prometheus.NewCounter(prometheus.CounterOpts{

--- a/meeseeks/metrics/metrics.go
+++ b/meeseeks/metrics/metrics.go
@@ -97,5 +97,6 @@ func init() {
 	prometheus.MustRegister(SuccessfulTasksCount)
 	prometheus.MustRegister(TaskDurations)
 	prometheus.MustRegister(LogLinesCount)
+	prometheus.MustRegister(buildInfo)
 	prometheus.MustRegister(bootTime)
 }

--- a/meeseeks/metrics/metrics.go
+++ b/meeseeks/metrics/metrics.go
@@ -15,6 +15,13 @@ var ReceivedCommandsCount = prometheus.NewCounter(prometheus.CounterOpts{
 	Help:      "Commands that have been received and are known",
 })
 
+// AliasedCommandsCount is the count of commands that have been received
+var AliasedCommandsCount = prometheus.NewCounter(prometheus.CounterOpts{
+	Namespace: namespace,
+	Name:      "aliased_commands_count",
+	Help:      "Commands that have been received and are an alias for another command",
+})
+
 // UnknownCommandsCount is the count of commands that have been received but are unknown
 var UnknownCommandsCount = prometheus.NewCounter(prometheus.CounterOpts{
 	Namespace: namespace,
@@ -82,6 +89,7 @@ func init() {
 	buildInfo.WithLabelValues(version.Name, version.Version, version.Date, version.Commit).Set(1)
 
 	prometheus.MustRegister(ReceivedCommandsCount)
+	prometheus.MustRegister(AliasedCommandsCount)
 	prometheus.MustRegister(UnknownCommandsCount)
 	prometheus.MustRegister(RejectedCommandsCount)
 	prometheus.MustRegister(AcceptedCommandsCount)

--- a/meeseeks/metrics/metrics.go
+++ b/meeseeks/metrics/metrics.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"github.com/gomeeseeks/meeseeks-box/version"
 	"github.com/prometheus/client_golang/prometheus"
 	"time"
 )
@@ -70,8 +71,15 @@ var bootTime = prometheus.NewGauge(prometheus.GaugeOpts{
 	Help:      "unix timestamp of when the meeseeks process was started",
 })
 
+var buildInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: namespace,
+	Name:      "build_info",
+	Help:      "Version of the meeseeks executable",
+}, []string{"name", "version", "date", "revision"})
+
 func init() {
 	bootTime.Set(float64(time.Now().Unix()))
+	buildInfo.WithLabelValues(version.Name, version.Version, version.Date, version.Commit).Set(1)
 
 	prometheus.MustRegister(ReceivedCommandsCount)
 	prometheus.MustRegister(UnknownCommandsCount)


### PR DESCRIPTION
A bunch of things.

- a bug fix to stop leaking commands
- add a metric with the build info
- add a metric to count command aliases
- add the command to the command execution buckets
- log the aliased command and not the alias