### PR TITLE
Handle context cancellation properly in the shell command

### DIFF
--- a/commands/shell/shell.go
+++ b/commands/shell/shell.go
@@ -86,9 +86,16 @@ func (c shellCommand) Execute(ctx context.Context, job meeseeks.Job) (string, er
 		return "", SetError(err)
 	}
 
-	<-done
+	// Wait for the command to be done or the context to be cancelled
+	select {
+	case <-ctx.Done():
+		// We are finishing because the context was called
+		err = ctx.Err()
+	case <-done:
+		// We are finishing because we are actually done
+		err = cmd.Wait()
+	}
 
-	err = cmd.Wait()
 	if err != nil {
 		logrus.Errorf("command failed: %s", err)
 		return "", SetError(err)

--- a/commands/shell/shell_test.go
+++ b/commands/shell/shell_test.go
@@ -71,6 +71,6 @@ func TestSleepingCanBeWokenUp(t *testing.T) {
 			ID:      3,
 			Request: meeseeks.Request{},
 		})
-		mocks.AssertEquals(t, "signal: killed", err.Error())
+		mocks.AssertEquals(t, "context canceled", err.Error())
 	})
 }


### PR DESCRIPTION
We were leaving zombies behind because we should have picked the context error instead of waiting for the process one. This way we get the context error and report that back because the command itself is dead already.

This way, long-running commands are killed immediately.