### PR TITLE
Initial step to push the formatter away by using a singleton

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,16 +12,9 @@ import (
 
 	"github.com/gomeeseeks/meeseeks-box/auth"
 	"github.com/gomeeseeks/meeseeks-box/db"
+	"github.com/gomeeseeks/meeseeks-box/formatter"
 
 	yaml "gopkg.in/yaml.v2"
-)
-
-// Default colors
-const (
-	DefaultInfoColorMessage    = ""
-	DefaultSuccessColorMessage = "good"
-	DefaultWarningColorMessage = "warning"
-	DefaultErrColorMessage     = "danger"
 )
 
 // LoadFile reads the given filename, builds a configuration object and initializes
@@ -45,6 +38,7 @@ func LoadConfig(cnf Config) error {
 		return err
 	}
 	auth.Configure(cnf.Groups)
+	formatter.Configure(cnf.Messages, cnf.Format)
 
 	for name, cmd := range cnf.Commands {
 		commands.Add(name, shell.New(shell.CommandOpts{
@@ -73,11 +67,11 @@ func New(r io.Reader) (Config, error) {
 			Mode:    0600,
 			Timeout: 2 * time.Second,
 		},
-		Format: Format{
-			Colors: MessageColors{
-				Info:    DefaultInfoColorMessage,
-				Success: DefaultSuccessColorMessage,
-				Error:   DefaultErrColorMessage,
+		Format: formatter.FormatConfig{
+			Colors: formatter.MessageColors{
+				Info:    formatter.DefaultInfoColorMessage,
+				Success: formatter.DefaultSuccessColorMessage,
+				Error:   formatter.DefaultErrColorMessage,
 			},
 			ReplyStyle: map[string]string{},
 		},
@@ -99,12 +93,12 @@ func New(r io.Reader) (Config, error) {
 
 // Config is the struct used to load MrMeeseeks configuration yaml
 type Config struct {
-	Database db.DatabaseConfig   `yaml:"database"`
-	Messages map[string][]string `yaml:"messages"`
-	Commands map[string]Command  `yaml:"commands"`
-	Groups   map[string][]string `yaml:"groups"`
-	Pool     int                 `yaml:"pool"`
-	Format   Format              `yaml:"format"`
+	Database db.DatabaseConfig      `yaml:"database"`
+	Messages map[string][]string    `yaml:"messages"`
+	Commands map[string]Command     `yaml:"commands"`
+	Groups   map[string][]string    `yaml:"groups"`
+	Pool     int                    `yaml:"pool"`
+	Format   formatter.FormatConfig `yaml:"format"`
 }
 
 // Command is the struct that handles a command configuration
@@ -125,17 +119,4 @@ type Command struct {
 type CommandHelp struct {
 	Summary string   `yaml:"summary"`
 	Args    []string `yaml:"args"`
-}
-
-// MessageColors contains the configured reply message colora
-type MessageColors struct {
-	Info    string `yaml:"info"`
-	Success string `yaml:"success"`
-	Error   string `yaml:"error"`
-}
-
-// Format contains the formatting configurations
-type Format struct {
-	Colors     MessageColors     `yaml:"colors"`
-	ReplyStyle map[string]string `yaml:"reply_styles"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,14 +10,15 @@ import (
 
 	"github.com/gomeeseeks/meeseeks-box/config"
 	"github.com/gomeeseeks/meeseeks-box/db"
+	"github.com/gomeeseeks/meeseeks-box/formatter"
 	"github.com/renstrom/dedent"
 )
 
 func Test_ConfigurationReading(t *testing.T) {
-	defaultColors := config.MessageColors{
-		Info:    config.DefaultInfoColorMessage,
-		Error:   config.DefaultErrColorMessage,
-		Success: config.DefaultSuccessColorMessage,
+	defaultColors := formatter.MessageColors{
+		Info:    formatter.DefaultInfoColorMessage,
+		Error:   formatter.DefaultErrColorMessage,
+		Success: formatter.DefaultSuccessColorMessage,
 	}
 	defaultDatabase := db.DatabaseConfig{
 		Path:    "meeseeks.db",
@@ -33,7 +34,7 @@ func Test_ConfigurationReading(t *testing.T) {
 			"Default configuration",
 			"",
 			config.Config{
-				Format: config.Format{
+				Format: formatter.FormatConfig{
 					Colors:     defaultColors,
 					ReplyStyle: map[string]string{},
 				},
@@ -51,7 +52,7 @@ func Test_ConfigurationReading(t *testing.T) {
 				Messages: map[string][]string{
 					"handshake": {"hallo"},
 				},
-				Format: config.Format{
+				Format: formatter.FormatConfig{
 					Colors:     defaultColors,
 					ReplyStyle: map[string]string{},
 				},
@@ -69,8 +70,8 @@ func Test_ConfigurationReading(t *testing.T) {
 				    error: "#000000"
 				`),
 			config.Config{
-				Format: config.Format{
-					Colors: config.MessageColors{
+				Format: formatter.FormatConfig{
+					Colors: formatter.MessageColors{
 						Info:    "#FFFFFF",
 						Success: "#CCCCCC",
 						Error:   "#000000",
@@ -97,7 +98,7 @@ func Test_ConfigurationReading(t *testing.T) {
 						Args: []string{"none"},
 					},
 				},
-				Format: config.Format{
+				Format: formatter.FormatConfig{
 					Colors:     defaultColors,
 					ReplyStyle: map[string]string{},
 				},

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -3,30 +3,54 @@ package formatter
 import (
 	"fmt"
 
-	"github.com/sirupsen/logrus"
-
-	"github.com/gomeeseeks/meeseeks-box/config"
 	"github.com/gomeeseeks/meeseeks-box/meeseeks"
 	"github.com/gomeeseeks/meeseeks-box/template"
+	"github.com/sirupsen/logrus"
 )
+
+// Default colors
+const (
+	DefaultInfoColorMessage    = ""
+	DefaultSuccessColorMessage = "good"
+	DefaultWarningColorMessage = "warning"
+	DefaultErrColorMessage     = "danger"
+)
+
+// MessageColors contains the configured reply message colora
+type MessageColors struct {
+	Info    string `yaml:"info"`
+	Success string `yaml:"success"`
+	Error   string `yaml:"error"`
+}
+
+// FormatConfig contains the formatting configurations
+type FormatConfig struct {
+	Colors     MessageColors     `yaml:"colors"`
+	ReplyStyle map[string]string `yaml:"reply_styles"`
+}
 
 // Formatter keeps the colors and templates used to format a reply message
 type Formatter struct {
-	colors     config.MessageColors
+	colors     MessageColors
 	templates  *template.TemplatesBuilder
 	replyStyle replyStyle
 }
 
-// New returns a new Formatter
-func New(cnf config.Config) *Formatter {
-	builder := template.NewBuilder().WithMessages(cnf.Messages)
-	f := Formatter{
-		replyStyle: replyStyle{cnf.Format.ReplyStyle},
-		colors:     cnf.Format.Colors,
+var formatter *Formatter
+
+// Configure sets up the singleton formatter
+func Configure(messages map[string][]string, cnf FormatConfig) {
+	builder := template.NewBuilder().WithMessages(messages)
+	formatter = &Formatter{
+		replyStyle: replyStyle{cnf.ReplyStyle},
+		colors:     cnf.Colors,
 		templates:  builder,
 	}
-	logrus.Debugf("Building new formatter %#v", f)
-	return &f
+}
+
+// Get returns the configured singleton formatter
+func Get() *Formatter {
+	return formatter
 }
 
 // Templates returns a clone of the default templates ready to be consumed
@@ -108,7 +132,7 @@ type Reply struct {
 	output string
 	err    error
 
-	colors    config.MessageColors
+	colors    MessageColors
 	templates *template.TemplatesBuilder
 	style     string
 }

--- a/main.go
+++ b/main.go
@@ -6,8 +6,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/gomeeseeks/meeseeks-box/formatter"
-
 	"github.com/gomeeseeks/meeseeks-box/api"
 	"github.com/gomeeseeks/meeseeks-box/config"
 	"github.com/gomeeseeks/meeseeks-box/jobs"
@@ -24,7 +22,7 @@ func main() {
 	args := parseArgs()
 
 	setLogLevel(args)
-	cnf := loadConfiguration(args)
+	loadConfiguration(args)
 
 	cleanupPendingJobs()
 
@@ -44,7 +42,7 @@ func main() {
 	}
 	logrus.Info("Listening to slack messages")
 
-	meeseek := executor.New(slackClient, msgs, formatter.New(cnf))
+	meeseek := executor.New(slackClient, msgs)
 	go meeseek.Start()
 	logrus.Info("Started commands pipeline")
 
@@ -104,7 +102,7 @@ func setLogLevel(args args) {
 	}
 }
 
-func loadConfiguration(args args) config.Config {
+func loadConfiguration(args args) {
 	cnf, err := config.LoadFile(args.ConfigFile)
 	if err != nil {
 		logrus.Fatal(err)
@@ -113,8 +111,6 @@ func loadConfiguration(args args) config.Config {
 		logrus.Fatalf("Could not load configuration: %s", err)
 	}
 	logrus.Info("Configuration loaded")
-
-	return cnf
 }
 
 func cleanupPendingJobs() {

--- a/meeseeks/executor/executor_test.go
+++ b/meeseeks/executor/executor_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gomeeseeks/meeseeks-box/formatter"
 	"github.com/gomeeseeks/meeseeks-box/meeseeks/executor"
 	"github.com/gomeeseeks/meeseeks-box/messenger"
 	"github.com/gomeeseeks/meeseeks-box/mocks"
@@ -127,7 +126,7 @@ func Test_MeeseeksInteractions(t *testing.T) {
 	}
 
 	mocks.WithTmpDB(func(dbpath string) {
-		client, cnf := mocks.NewHarness().
+		client := mocks.NewHarness().
 			WithConfig(dedent.Dedent(`
 			---
 			commands:
@@ -152,7 +151,7 @@ func Test_MeeseeksInteractions(t *testing.T) {
 		if err != nil {
 			t.Fatalf("could not create listener: %s", err)
 		}
-		m := executor.New(client, msgs, formatter.New(cnf))
+		m := executor.New(client, msgs)
 		go m.Start()
 
 		for _, tc := range tt {

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -73,7 +73,7 @@ func (h Harness) WithDBPath(dbpath string) Harness {
 }
 
 // Load creates a clientStub and a configuration based on the provided one
-func (h Harness) Load() (ClientStub, config.Config) {
+func (h Harness) Load() ClientStub {
 	c, err := config.New(strings.NewReader(h.cnf))
 	if err != nil {
 		logrus.Fatalf("Could not build test harness: %s", err)
@@ -87,9 +87,9 @@ func (h Harness) Load() (ClientStub, config.Config) {
 	}
 	if err := config.LoadConfig(c); err != nil {
 		fmt.Printf("Failed to load configuration: %s", err)
-		return ClientStub{}, c
+		return ClientStub{}
 	}
-	return newClientStub(), c
+	return newClientStub()
 }
 
 // ClientStub is an extremely simple implementation of a client that only captures messages


### PR DESCRIPTION
This way it's consistent with other packages and we simplify the interface and the configuration in the case of reloading the configuration with signals.